### PR TITLE
Removed unused key from App.xaml

### DIFF
--- a/Microsoft-Graph-UWP-Connect-SDK/App.xaml
+++ b/Microsoft-Graph-UWP-Connect-SDK/App.xaml
@@ -13,9 +13,6 @@ See LICENSE in the project root for license information. -->
         <!--<x:String x:Key="ida:ClientID">aed1bde9-797f-4f5c-b65b-211585f9cdfe</x:String>-->
         <x:String x:Key="ida:ClientID"></x:String>
         <x:String x:Key="ida:ReturnUrl">urn:ietf:wg:oauth:2.0:oob</x:String>
-        <!--<x:String x:Key="ida:AADInstance">https://login.microsoftonline.com/</x:String>-->
-        <!-- Add your developer tenant domain here. -->
-        <!--<x:String x:Key="ida:Domain">ENTER_YOUR_TENANT.onmicrosoft.com</x:String>-->
     </Application.Resources>
 
     


### PR DESCRIPTION
Removed the (already commented out) "ida:AADInstance" key from the
application resources section of App.xaml, since the sample now uses the
v2.0 auth endpoint.
